### PR TITLE
v1.0.2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,18 @@ Visit the above URL to request an API key from the test Open311 system. Your req
 
 Production API keys may only be requested after successfully testing with a test API key. The API Key application you submit will need to be reviewed and approved by City of Chicago Staff to ensure compliance with the [Terms of Service](tos/).
 
-## Service Request Meta Data
+## Endpoints
+
+Below are the API endpoints that can be used to access the Open311 API. 
+
+|   Staging  |                API Endpoint                     |
+|------------|-------------------------------------------------|
+| Test       | http://test311api.cityofchicago.org/open311/v2/ |
+| Production | http://311api.cityofchicago.org/open311/v2/     |
+
+The API has two categories of information: metadata about the types of service requests and interacting with service requests.
+
+### Service Request Metadata
 
 Methods that expose data related to how Service Requests will be exposed in the API.
 
@@ -42,7 +53,7 @@ Methods that expose data related to how Service Requests will be exposed in the 
 | GET services.:format | **Service List**: Provide a list of acceptable 311 service request types and their associated service codes. |
 | GET services/:service_code.:format | **Service Definition**: Define attributes associated with a service code. |
 
-## Service Request
+### Service Request
 
 Methods that allow for reading and writing of Service Requests to the City database.
 

--- a/docs/post_service_request.md
+++ b/docs/post_service_request.md
@@ -11,26 +11,26 @@ Create a service request in the City's database. Once a service request has been
 
 ## Arguments
 
-|     Argument       | Required |                       Description                         |
-|--------------------|----------|-----------------------------------------------------------|
-| `jurisdiction_id`  | optional | This is currently optional on Chicago's Open311 endpoint. |
-| `service_code`     | required | This is obtained from GET Service List method.            |
+|     Argument       | Required |                                                Description                                                             |
+|--------------------|----------|------------------------------------------------------------------------------------------------------------------------|
+| `jurisdiction_id`  | optional | Optional, but if it is included, it must be set to `cityofchicago.org`                                                 |
+| `service_code`     | required | This is obtained from GET Service List method.                                                                         |
 | `attribute`        | required | This takes the form of attribute[code]=value where multiple code/value pairs can be specified as well as multiple values for the same code in the case of a multivaluelist datatype (attribute[code1][]=value1&attribute[code1][]=value2&attribute[code1][]=value3) - see example. - This is only required if the service_code requires a service definition with required fields. |
 | `lat`              | required | lat &amp; long both need to be sent even though they are sent as two separate parameters. lat &amp; long are required. |
 | `long`             | required | lat &amp; long both need to be sent even though they are sent as two separate parameters. lat &amp; long are required. |
-| `address_string`   | required | This should be written from most specific to most general geographic unit, eg address number or cross streets, street name, neighborhood/district, city/town/village, county, postal code.  |
-| `address_id`       | optional | The internal address ID used by a jurisdiction's master address repository or other addressing system. |
-| `email`            | optional | The email address of the person submitting the request.   |
-| `device_id`        | optional | The unique device ID of the device submitting the request. This is usually only used for mobile devices. |
-| `account_id`       | optional | The unique ID for the user account of the person submitting the request. |
-| `first_name`       | optional | The given name of the person submitting the request.      |
-| `last_name`        | optional | The family name of the person submitting the request.     |
-| `phone`            | optional | The phone number of the person submitting the request.    |
-| `description`      | optional | A full description of the request or report being submitted. |
-| `media_url`        | optional | A URL to media associated with the request, eg an image.  |
+| `address_string`   | required | This should be written from most specific to most general geographic unit, eg address number or cross streets, street name, neighborhood/district, city/town/village, county, postal code. |
+| `address_id`       | optional | The internal address ID used by a jurisdiction's master address repository or other addressing system.                 |
+| `email`            | optional | The email address of the person submitting the request.                                                                |
+| `device_id`        | optional | The unique device ID of the device submitting the request. This is usually only used for mobile devices.               |
+| `account_id`       | optional | The unique ID for the user account of the person submitting the request.                                               |
+| `first_name`       | optional | The given name of the person submitting the request.                                                                   |
+| `last_name`        | optional | The family name of the person submitting the request.                                                                  |
+| `phone`            | optional | The phone number of the person submitting the request.                                                                 |
+| `description`      | optional | A full description of the request or report being submitted.                                                           |
+| `media_url`        | optional | A URL to media associated with the request, eg an image.                                                               |
 
 ## Response Parameters
 
-| Argument |                        Description                                     |
-|----------|------------------------------------------------------------------------|
+| Argument |                                                                           Description                                                                |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `token`  | If returned, use this to call GET service_request_id from a token to discover what the service_request_id is after it is created by the City system. |

--- a/docs/post_service_request.md
+++ b/docs/post_service_request.md
@@ -1,13 +1,13 @@
-# POST requests.:format
+# Create a New Service Request
 
 Create a service request in the City's database. Once a service request has been processed by the City (this can take an undetermined amount of time), you should be able to call the GET service_request_id method (tokens/:token_id.:format) to get back the service_request_id for a SR. Therefore, it is nesseary to poll the GET service_request_id method until an SR id is returned. Because the Chicago endpoint may return service requests with no token and no service_reqeust_id in calls to GET service_requests while recently submitted SRs are still being processed by City systems, users of the GET service_requests method should ignore any service requests returned by the API until they have a service_request_id.
 
-| Resource Information |                      |
-|----------------------|----------------------|
-| Method Name          | Post Service Request |
-| Requires API key?    | Yes                  |
-| Response Formats     | JSON, XML            |
-| HTTP Methods         | POST                 |
+| Resource Information |                       |
+|----------------------|-----------------------|
+| Method               | POST requests.:format |
+| Requires API key?    | Yes                   |
+| Response Formats     | JSON, XML             |
+| HTTP Methods         | POST                  |
 
 ## Arguments
 

--- a/docs/post_service_request.md
+++ b/docs/post_service_request.md
@@ -5,10 +5,9 @@ Create a service request in the City's database. Once a service request has been
 | Resource Information |                      |
 |----------------------|----------------------|
 | Method Name          | Post Service Request |
-| Requires API key?    | No                   |
+| Requires API key?    | Yes                  |
 | Response Formats     | JSON, XML            |
-| HTTP Methods         | GET                  |
-| JSONP                | POST                 |
+| HTTP Methods         | POST                 |
 
 ## Arguments
 

--- a/docs/service_definition.md
+++ b/docs/service_definition.md
@@ -1,14 +1,14 @@
-# GET services/:service_code.:format
+# Retrieve the Definitions for a Service Request
 
 Define attributes associated with a service code.
 
-| Resource Information |     |
-|----------------------|-----|
-| Method Name | Service Definition |
-| Requires API key? | No |
-| Response Formats | JSON, XML |
-| HTTP Methods | GET |
-| JSONP | callback=? |
+| Resource Information |                                    |
+|----------------------|------------------------------------|
+| Method               | GET services/:service_code.:format |
+| Requires API key?    | No                                 |
+| Response Formats     | JSON, XML                          |
+| HTTP Methods         | GET                                |
+| JSONP                | callback=?                         |
 
 ## Arguments
 

--- a/docs/service_definition.md
+++ b/docs/service_definition.md
@@ -12,22 +12,22 @@ Define attributes associated with a service code.
 
 ## Arguments
 
-|     Argument      | Required |                        Description                        |
-|-------------------|----------|-----------------------------------------------------------|
-| `jurisdiction_id` | optional | This is currently optional on Chicago's Open311 endpoint. |
+|     Argument      | Required |                                     Description                                                 |
+|-------------------|----------|-------------------------------------------------------------------------------------------------|
+| `jurisdiction_id` | optional | Optional, but if it is included, it must be set to `cityofchicago.org`                          |
 | `service_code`    | required | The service_code is specified in the main URL path rather than an added query string parameter. |
 
 ## Response Parameters
 
 |     Argument   |                        Description                                     |
 |----------------|------------------------------------------------------------------------|
-| `service_code` | Returns the service_code associated with the definition, the same one submitted for this call. |
-| `variable` | 'true' denotes that user input is needed. 'false' means the attribute is only used to present information to the user within the description field. |
-| `code` | A unique identifier for the attribute. |
-| `datatype` | Denotes the type of field used for user input. |
-| `required` | 'true' means that the value is required to submit service request. 'false' means that the value not required. |
+| `service_code`         | Returns the service_code associated with the definition, the same one submitted for this call. |
+| `variable`             | 'true' denotes that user input is needed. 'false' means the attribute is only used to present information to the user within the description field. |
+| `code`                 | A unique identifier for the attribute. |
+| `datatype`             | Denotes the type of field used for user input. |
+| `required`             | 'true' means that the value is required to submit service request. 'false' means that the value not required. |
 | `datatype_description` | A description of the datatype which helps the user provide their input. |
-| `order` | The sort order that the attributes will be presented to the user. 1 is shown first in the list. |
-| `description` | A description of the attribute field with instructions for the user to find and identify the requested information. |
-| `key` | The unique identifier associated with an option for singlevaluelist or multivaluelist. This is analogous to the value attribute in an html option tag. |
-| `name` | The human readable title of an option for singlevaluelist or multivaluelist. This is analogous to the innerhtml text node of an html option tag. |
+| `order`                | The sort order that the attributes will be presented to the user. 1 is shown first in the list. |
+| `description`          | A description of the attribute field with instructions for the user to find and identify the requested information. |
+| `key`                  | The unique identifier associated with an option for singlevaluelist or multivaluelist. This is analogous to the value attribute in an html option tag.|
+| `name`                 | The human readable title of an option for singlevaluelist or multivaluelist. This is analogous to the innerhtml text node of an html option tag. |

--- a/docs/service_list.md
+++ b/docs/service_list.md
@@ -12,9 +12,9 @@ Provide a list of acceptable 311 service request types and their associated serv
 
 ## Arguments
 
-|     Argument      | Required |                        Description                        |
-|-------------------|----------|-----------------------------------------------------------|
-| `jurisdiction_id` | optional | This is currently optional on Chicago's Open311 endpoint. |
+|     Argument      | Required |                                Description                             |
+|-------------------|----------|------------------------------------------------------------------------|
+| `jurisdiction_id` | optional | Optional, but if it is included, it must be set to `cityofchicago.org` |
 
 ## Response Parameters
 

--- a/docs/service_list.md
+++ b/docs/service_list.md
@@ -1,14 +1,14 @@
-# GET services.:format
+# List Available Open311 Services
 
 Provide a list of acceptable 311 service request types and their associated service codes.
 
-| Resource Information |     |
-|----------------------|-----|
-| Method Name | Service List |
-| Requires API key? | No |
-| Response Formats | JSON, XML |
-| HTTP Methods | GET |
-| JSONP | callback=? |
+| Resource Information |                      |
+|----------------------|----------------------|
+| Method               | GET services.:format |
+| Requires API key?    | No                   |
+| Response Formats     | JSON, XML            |
+| HTTP Methods         | GET                  |
+| JSONP                | callback=?           |
 
 ## Arguments
 

--- a/docs/service_request.md
+++ b/docs/service_request.md
@@ -1,14 +1,14 @@
-# GET services/:service_code.:format
+# Retrieving an Individual Request
 
 Define attributes associated with a service code.
 
-| Resource Information |     |
-|----------------------|-----|
-| Method Name | Service Definition |
-| Requires API key? | No |
-| Response Formats | JSON, XML |
-| HTTP Methods | GET |
-| JSONP | callback=? |
+| Resource Information |                                          |
+|----------------------|------------------------------------------|
+| Method               | GET requests/:service_request_id.:format |
+| Requires API key?    | No                                       |
+| Response Formats     | JSON, XML                                |
+| HTTP Methods         | GET                                      |
+| JSONP                | callback=?                               |
 
 ## Arguments
 

--- a/docs/service_request.md
+++ b/docs/service_request.md
@@ -12,9 +12,9 @@ Define attributes associated with a service code.
 
 ## Arguments
 
-|     Argument      | Required |                        Description                        |
-|-------------------|----------|-----------------------------------------------------------|
-| `jurisdiction_id` | optional | This is currently optional on Chicago's Open311 endpoint. |
+|     Argument      | Required |                                      Description                                                |
+|-------------------|----------|-------------------------------------------------------------------------------------------------|
+| `jurisdiction_id` | optional | Optional, but if it is included, it must be set to `cityofchicago.org`                          |
 | `service_code`    | required | The service_code is specified in the main URL path rather than an added query string parameter. |
 | `extensions`      | optional | The Chicago Open311 endpoint provides supplemental details about Service Requests that are in addition to the ones described in the standard specification. These data are nested in the 'extended_attributes' field in the Service Request response. In order to retrieve the new supplemental details, add the query parameter “extensions=true” to any Open 311 api request. |
 

--- a/docs/service_requests.md
+++ b/docs/service_requests.md
@@ -14,7 +14,7 @@ Query the current status of multiple requests. Because the Chicago endpoint may 
 
 |     Argument         | Required |              |                       Description                        |
 |----------------------|----------|--------------|----------------------------------------------------------|
-| `jurisdiction_id`    | optional |              | This is currently optional on Chicago's Open311 endpoint. |
+| `jurisdiction_id`    | optional |              | Optional, but if it is included, it must be set to `cityofchicago.org` |
 | `service_request_id` | optional |              | To call multiple Service Requests at once, multiple service_request_id can be declared; comma delimited. |
 | `service_code`       | optional |              | Specify the service type by calling the unique ID(s) of the service_codes you wish to query. This defaults to all service codes when not declared; can be declared multiple times, comma delimited (no spaces). |
 | `start_date`         | optional |              | Earliest datetime to include in search. When provided with end_date, allows one to search for requests which have a requested_datetime that matches a given range. Must use w3 format, eg 2010-01-01T00:00:00Z. |

--- a/docs/service_requests.md
+++ b/docs/service_requests.md
@@ -1,14 +1,14 @@
-# GET requests.:format
+# Query the Current Status of Multiple Requests
 
 Query the current status of multiple requests. Because the Chicago endpoint may return service requests with no token and no service_reqeust_id in calls to GET service_requests while recently submitted SRs are still being processed by City systems, users of the GET service_requests method should ignore any service requests returned by the API until they have a service_request_id.
 
-| Resource Information |     |
-|----------------------|-----|
-| Method Name | Service Definition |
-| Requires API key? | No |
-| Response Formats | JSON, XML |
-| HTTP Methods | GET |
-| JSONP | callback=? |
+| Resource Information |                      |
+|----------------------|----------------------|
+| Method               | GET requests.:format |
+| Requires API key?    | No                   |
+| Response Formats     | JSON, XML            |
+| HTTP Methods         | GET                  |
+| JSONP                | callback=?           |
 
 ## Arguments
 

--- a/docs/service_requests.md
+++ b/docs/service_requests.md
@@ -34,13 +34,13 @@ Query the current status of multiple requests. Because the Chicago endpoint may 
 |----------------|--------------|------------------------------------------------------------------------|
 | `service_request_id` | | 	The unique ID of the service request created. |
 | `service_code` | | Returns the service_code associated with the definition, the same one submitted for this call. |
-| `status` | The current status of the service request. |
+| `status` | | The current status of the service request. |
 | `status_notes` | |Explanation of why status was changed to current state or more details on current status than conveyed with status alone. |
 | `service_name` | | The human readable name of the service request type. |
 | `service_code` | | The unique identifier for the service request type. |
 | `description` | | A full description of the request or report submitted. |
 | `agency_responsible` | | The agency responsible for fulfilling or otherwise addressing the service request. | |
-| `service_notice` | Information about the action expected to fulfill the request or otherwise address the information reported. |
+| `service_notice` | | Information about the action expected to fulfill the request or otherwise address the information reported. |
 | `requested_datetime` | | The date and time when the service request was made. |
 | `updated_datetime` | Non-standard | TBD: The Chicago implementation uses updated_datetime in a manner that differs from Open311. Documentation is still being compiled. |
 | `expected_datetime` | | The date and time when the service request can be expected to be fulfilled. This may be based on a service-specific service level agreement. |


### PR DESCRIPTION
This contains a number of fixes and corrections:
  * Corrected several significant errors where the `GET` commands were wrong
  * Fixed a type-o to clarify the `POST` command requires an API key #8
  * Added links to the API endpoints for clarity #7 
  * Contains minor formatting fixes #9 
  * Added other grammatical fixes and improve formatted of the underlying Markdown for some tables.